### PR TITLE
Add blog-post skill: outline-first, visualization-driven workflow

### DIFF
--- a/.claude/skills/blog-post/SKILL.md
+++ b/.claude/skills/blog-post/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: blog-post
+description: Use when starting a new blog post on this site, turning an idea into a post, or continuing a draft in packages/website/src/routes/posts. The workflow deliberately caps how much prose gets written and spends the effort on an interactive visualization instead.
+---
+
+Posts on this site work because a visualization does the explaining and the
+prose does the framing, not the other way around. "Visualizing Voting
+Systems" makes the spoiler effect obvious by letting you drag a candidate
+around a Yee diagram; "Pi By Hand" makes a binary-search algorithm legible by
+animating it column by column. In both cases the surrounding text is short —
+it sets up a question, points at the diagram, and interprets what happened.
+Take that away and the post has nothing left to say. That's the target: if
+you deleted the visualization, would the post collapse? If not, the
+visualization isn't doing enough work yet.
+
+The failure mode this skill exists to prevent is writing the whole essay
+first and bolting a chart on afterward. Once a paragraph fully explains an
+idea in words, there's no pressure left to build something that shows it,
+and the visualization becomes decoration. Build the visualization while the
+idea still needs it.
+
+## Workflow
+
+**1. State the idea in one or two sentences.** What's the actual claim, and
+where is the moment a reader needs to *see* something rather than be told
+it? If you can't name that moment, you don't have a post yet, you have a
+topic.
+
+**2. Write an outline, not a draft.** Headers plus one line per section
+describing what it argues or shows, and which section(s) need a
+visualization. No full paragraphs at this stage — if you catch yourself
+writing a real paragraph during outlining, stop and go build instead. Keep
+the outline in the post file itself (frontmatter `status: draft`), or
+sketch it in the scratchpad first if you want to iterate before touching
+the repo.
+
+**3. For each outline beat, ask what a reader could manipulate, not what
+chart would depict it.** "What parameter, if the reader dragged or toggled
+it, would make the idea click?" beats "what static chart summarizes this
+fact?" Look at existing components for the shape of an answer:
+- `packages/website/src/lib/voting/Simulation.svelte` +
+  `YeeDiagram.svelte` — drag candidates, click to re-simulate, watch the
+  outcome region change live.
+- `packages/website/src/lib/circles/{Darts,Sequential,BinarySearch}.svelte`
+  — the same problem solved three ways, each one a step in an argument
+  about algorithm design.
+- `packages/website/src/lib/VegaLite.svelte` — a thin Vega-Lite wrapper for
+  when the point really is a static chart and interactivity would be noise.
+  Don't reach for this by default; the site's strongest posts are bespoke
+  Svelte components, not spec-driven charts.
+
+If a beat in the outline has no visualization and needs more than a
+paragraph or two of prose to land, that's usually a sign it wants a diagram
+instead of more words — reconsider before writing your way through it.
+
+**4. Build the visualization before writing the prose around it.** Create
+the component(s) under `packages/website/src/lib/<topic>/`, scoped tightly
+to what this post needs (2-4 small components, not a generic charting
+library). Wire it into the draft `.mdx` immediately so you can see it in
+the browser rather than judging it as code:
+
+```bash
+npm run dev   # or: nx dev website
+```
+
+then visit `/posts/<slug>`. Iterate on the visualization itself — the
+interaction, the parameters, what's draggable or clickable — until it
+actually carries the idea from step 1. This is where most of the effort in
+a post should go.
+
+**5. Only after the visualization works, fill in the minimal prose.** Each
+paragraph's job is to set up context before a visualization or interpret
+what the reader just did after one. If a paragraph could be deleted without
+losing the argument, delete it.
+
+**6. Lazy-load anything expensive.** Wrap heavier interactive components in
+`<IntersectionObserver initialHeight={N}>` (see
+`static-rendering-in-sveltekit.mdx`-era posts or `visualizing-voting-systems.mdx`
+for the pattern) so they don't run until scrolled into view.
+
+## File conventions
+
+- Location: `packages/website/src/routes/posts/<kebab-case-slug>.mdx` — the
+  filename (minus extension) is the slug.
+- Frontmatter:
+  ```
+  ---
+  title: 'Human-readable title'
+  date: YYYY-MM-DD HH:MM:SS
+  status: draft
+  blurb: One or two sentences used as the teaser on the index page.
+  ---
+  ```
+  `status` must be exactly `published` for a post to appear in the index
+  (see `packages/website/src/lib/getPosts.ts`); leave it as `draft` for
+  anything still in progress. Write `blurb` deliberately rather than
+  relying on the first-paragraph fallback — with prose kept minimal, the
+  first paragraph is often too thin to stand alone as a teaser.
+- Svelte components (including data prep helpers like `elections.ts`) are
+  imported in an mdx `<script>` block using `$lib/...` paths, then used as
+  JSX-like tags in the body — see the top of `visualizing-voting-systems.mdx`
+  for the pattern.
+
+## Anti-patterns
+
+- Writing a full draft before any visualization exists.
+- A visualization that only restates a sentence already in the prose above
+  it, instead of showing something the prose can't.
+- Building a reusable/generic charting abstraction when the post only needs
+  one specific interaction.
+- Padding a section with explanation because building the visualization
+  felt harder than writing around it.

--- a/.claude/skills/blog-post/SKILL.md
+++ b/.claude/skills/blog-post/SKILL.md
@@ -26,13 +26,14 @@ where is the moment a reader needs to *see* something rather than be told
 it? If you can't name that moment, you don't have a post yet, you have a
 topic.
 
-**2. Write an outline, not a draft.** Headers plus one line per section
-describing what it argues or shows, and which section(s) need a
-visualization. No full paragraphs at this stage — if you catch yourself
-writing a real paragraph during outlining, stop and go build instead. Keep
-the outline in the post file itself (frontmatter `status: draft`), or
-sketch it in the scratchpad first if you want to iterate before touching
-the repo.
+**2. Write an outline, not a draft.** Headers and, once it exists, the
+visualization's own caption — nothing else. No prose, and no explanatory
+one-liners under the headers either: if a header seems to need a sentence
+to make sense before its visualization exists, that's a sign to go build
+the visualization, not to write a placeholder sentence to tide it over. The
+header names the beat; the caption explains it once there's something to
+caption. If you catch yourself writing a real sentence of connective prose
+during outlining, stop — that sentence belongs in step 6, not here.
 
 **3. For each outline beat, ask what a reader could manipulate, not what
 chart would depict it.** "What parameter, if the reader dragged or toggled
@@ -53,27 +54,44 @@ If a beat in the outline has no visualization and needs more than a
 paragraph or two of prose to land, that's usually a sign it wants a diagram
 instead of more words — reconsider before writing your way through it.
 
-**4. Build the visualization before writing the prose around it.** Create
-the component(s) under `packages/website/src/lib/<topic>/`, scoped tightly
-to what this post needs (2-4 small components, not a generic charting
-library). Wire it into the draft `.mdx` immediately so you can see it in
-the browser rather than judging it as code:
+**4. Prototype the outline in an Artifact before touching Svelte.** Build a
+single self-contained HTML file — headers, a working reimplementation of
+each visualization (inline JS/SVG/Canvas; the Artifact CSP blocks CDNs and
+external requests, so port the actual logic in rather than linking d3 or
+similar), and captions, matching the outline exactly and nothing more.
+Publish it with the Artifact tool, and redeploy to the *same* URL
+(`url:` param) on every subsequent round so it stays one stable link to
+iterate against. Also send the file directly (`SendUserFile`) alongside it
+— the hosted artifact viewer isn't always reachable, and the raw HTML
+opens in any browser as a fallback. This loop is much cheaper than editing
+real Svelte components and running a dev server for every small change,
+and it's a shared surface: the user can react to structure and interaction
+choices before any of it is real. Keep outlining and reshaping the
+visualizations here until both are settled — this is where disagreements
+about the idea itself should surface and get resolved, before step 5 makes
+them expensive to change.
+
+**5. Port the settled prototype into the real components.** Once the
+outline and the interactions in the artifact are agreed, build the actual
+component(s) under `packages/website/src/lib/<topic>/`, scoped tightly to
+what this post needs (2-4 small components, not a generic charting
+library), and wire them into the draft `.mdx`. Verify in a real browser
+against a real dev server, not just by reading the code:
 
 ```bash
 npm run dev   # or: nx dev website
 ```
 
-then visit `/posts/<slug>`. Iterate on the visualization itself — the
-interaction, the parameters, what's draggable or clickable — until it
-actually carries the idea from step 1. This is where most of the effort in
-a post should go.
+then visit `/posts/<slug>`, and drive the interaction (drag, click,
+slider) the way the artifact prototype did, confirming it behaves the same
+way now that it's real.
 
-**5. Only after the visualization works, fill in the minimal prose.** Each
+**6. Only after the visualization works, fill in the minimal prose.** Each
 paragraph's job is to set up context before a visualization or interpret
 what the reader just did after one. If a paragraph could be deleted without
 losing the argument, delete it.
 
-**6. Lazy-load anything expensive.** Wrap heavier interactive components in
+**7. Lazy-load anything expensive.** Wrap heavier interactive components in
 `<IntersectionObserver initialHeight={N}>` (see
 `static-rendering-in-sveltekit.mdx`-era posts or `visualizing-voting-systems.mdx`
 for the pattern) so they don't run until scrolled into view.
@@ -104,6 +122,12 @@ for the pattern) so they don't run until scrolled into view.
 ## Anti-patterns
 
 - Writing a full draft before any visualization exists.
+- Writing outline one-liners or connective sentences "just to hold the
+  place" — the outline stage is headers and captions, full stop; anything
+  more is step 6 arriving early.
+- Jumping straight into editing Svelte components (and a dev server
+  restart per tweak) for a visualization idea that hasn't been settled yet
+  — prototype it in an Artifact first, where iteration is nearly free.
 - A visualization that only restates a sentence already in the prose above
   it, instead of showing something the prose can't.
 - Building a reusable/generic charting abstraction when the post only needs

--- a/packages/website/src/lib/voting/YeeDiagram.svelte
+++ b/packages/website/src/lib/voting/YeeDiagram.svelte
@@ -2,10 +2,11 @@
   import { Voronoi, randomLcg } from 'd3'
   import type { Selection } from 'd3'
   import type { Point, NamedPoint } from './types'
-  import { plurality, approval } from './elections'
+  import { plurality, approval, irv } from './elections'
   const methods = {
     plurality,
-    approval
+    approval,
+    irv
   }
   let created = 0
 </script>
@@ -24,6 +25,13 @@
   export let fidelity = 30
   export let seed = 1158
   export let method: keyof typeof methods = 'plurality'
+  // Per-candidate portrait images, keyed by candidate index. Omit an entry
+  // (or the whole prop) to fall back to the historical Bush/Gore/Nader
+  // portraits, or pass undefined entries to render plain colored dots.
+  export let portraits: (string | undefined)[] | undefined = undefined
+  // Splits the voter cloud into two equal poles, offset left/right of the
+  // sampled point by this amount, to model a polarized electorate.
+  export let polarization = 0
 
   let namedCandidates = candidates.map(([x, y], i) => ({ x, y, i }))
   let colors = scaleOrdinal(
@@ -32,13 +40,16 @@
   ).unknown('#000000')
   let pictures = scaleOrdinal(
     namedCandidates.map(({ i }) => i),
-    [gore, bush, nader]
+    portraits ?? [gore, bush, nader]
   )
 
   const voterDistribution = randomNormal.source(randomLcg(seed))(0, 20)
-  const voters: Point[] = new Array(nVoters)
+  const baseVoters: Point[] = new Array(nVoters)
     .fill(null)
     .map(() => [voterDistribution(), voterDistribution()])
+  $: voters = baseVoters.map(
+    ([x, y], idx): Point => [x + (idx % 2 === 0 ? -1 : 1) * polarization, y]
+  )
   const elect = methods[method]
   const winners: [Point, NamedPoint][] = new Array(fidelity ** 2)
   const imgSize = 10
@@ -112,13 +123,14 @@
       .attr('fill', ({ i }) => colors(i))
 
     candidateSelection
+      .filter(({ i }) => Boolean(pictures(i)))
       .append('image')
       .attr('width', imgSize)
       .attr('height', imgSize)
       .attr('x', -imgSize / 2)
       .attr('y', -imgSize / 2)
       .attr('clip-path', 'url(#imgClip)')
-      .attr('href', ({ i }) => pictures(i))
+      .attr('href', ({ i }) => pictures(i) as string)
   })
 </script>
 

--- a/packages/website/src/lib/voting/elections.ts
+++ b/packages/website/src/lib/voting/elections.ts
@@ -68,3 +68,46 @@ export const approval = (
     } else return winner
   }, odysseus)
 }
+
+// Ranked choice / instant runoff: each voter ranks candidates by distance.
+// Repeatedly eliminate the candidate with the fewest first-choice votes
+// among those still standing, transferring each of their voters to that
+// voter's next surviving preference, until someone has a majority.
+export const irv = (candidates: NamedPoint[], voters: Point[], [ox, oy]: Point): NamedPoint => {
+  const rankings = voters.map(([x, y]) =>
+    candidates
+      .map(({ x: cx, y: cy, i }) => ({ i, dist: euclidean([x + ox, y + oy], [cx, cy]) }))
+      .sort((a, b) => a.dist - b.dist)
+      .map(({ i }) => i)
+  )
+
+  const remaining = new Set(candidates.map(({ i }) => i))
+  while (remaining.size > 1) {
+    const tally: { [key in number]?: number } = {}
+    remaining.forEach((i) => (tally[i] = 0))
+    rankings.forEach((ranking) => {
+      const choice = ranking.find((i) => remaining.has(i))
+      if (choice !== undefined) tally[choice] = (tally[choice] ?? 0) + 1
+    })
+
+    const total = [...remaining].reduce((sum, i) => sum + (tally[i] ?? 0), 0)
+    let leader = [...remaining][0]
+    let trailer = [...remaining][0]
+    remaining.forEach((i) => {
+      if ((tally[i] ?? 0) > (tally[leader] ?? 0)) leader = i
+      if ((tally[i] ?? 0) < (tally[trailer] ?? 0)) trailer = i
+    })
+
+    if ((tally[leader] ?? 0) > total / 2) {
+      return candidates.find(({ i }) => i === leader) ?? odysseus
+    }
+    if (remaining.size === 2) {
+      // two candidates left and neither has a majority: exact tie
+      return odysseus
+    }
+    remaining.delete(trailer)
+  }
+
+  const [lastStanding] = remaining
+  return candidates.find(({ i }) => i === lastStanding) ?? odysseus
+}

--- a/packages/website/src/routes/posts/ranked-choice-has-a-spoiler-too.mdx
+++ b/packages/website/src/routes/posts/ranked-choice-has-a-spoiler-too.mdx
@@ -11,16 +11,14 @@ blurb: Ranked-choice voting is the standard fix for the spoiler effect that hand
   import { debounce } from '$lib/utilities'
 
   const candidates = [
-    [50, 30],
-    [50, 70],
-    [30, 15]
-  ]
-
-  const squeezeCandidates = [
-    [25, 50],
+    [35, 50],
     [50, 50],
-    [75, 50]
+    [65, 50]
   ]
+  const noPortraits = [undefined, undefined, undefined]
+  const seed = 4
+  const nVoters = 600
+  const approvalRadius = 28
 
   let polarization = 0
   const updatePolarization = debounce((e) => {
@@ -28,22 +26,12 @@ blurb: Ranked-choice voting is the standard fix for the spoiler effect that hand
   }, 100)
 </script>
 
-## Does instant runoff fix the spoiler effect?
-
-<IntersectionObserver initialHeight={600}>
-  <YeeDiagram
-    candidates={candidates}
-    method="irv"
-    label="The same 2000 candidates, counted by instant runoff instead of plurality. Compare this to the plurality diagram in the last post."
-  />
-</IntersectionObserver>
-
 ## Center squeeze
 
 <input
   type="range"
   min="0"
-  max="30"
+  max="18"
   value={polarization}
   on:input={updatePolarization}
   style="width: 100%; max-width: 600px; display: block; margin: 0 auto;"
@@ -51,11 +39,28 @@ blurb: Ranked-choice voting is the standard fix for the spoiler effect that hand
 
 <IntersectionObserver initialHeight={600}>
   <YeeDiagram
-    candidates={squeezeCandidates}
+    candidates={candidates}
     method="irv"
+    seed={seed}
+    nVoters={nVoters}
     polarization={polarization}
-    portraits={[undefined, undefined, undefined]}
-    label="Blue and yellow flank red at the center. As polarization rises, voters cluster around the two poles, red runs short of first-choice votes, and gets eliminated before its second-choice support ever counts."
+    portraits={noPortraits}
+    label="Three candidates in a line, all packed into the middle third. At rest, the moderate wins a perfectly reasonable central band. Drag the slider — as the electorate splits toward the two flanks, that band collapses, even though the moderate is still the closest candidate to the average voter right up until it loses."
+  />
+</IntersectionObserver>
+
+## The same electorate, under approval voting
+
+<IntersectionObserver initialHeight={600}>
+  <YeeDiagram
+    candidates={candidates}
+    method="approval"
+    r={approvalRadius}
+    seed={seed}
+    nVoters={nVoters}
+    polarization={polarization}
+    portraits={noPortraits}
+    label="Identical candidates, identical voters, same polarization slider as above — only the counting method changed. Watch the moderate's band as you drag: under approval voting it holds."
   />
 </IntersectionObserver>
 

--- a/packages/website/src/routes/posts/ranked-choice-has-a-spoiler-too.mdx
+++ b/packages/website/src/routes/posts/ranked-choice-has-a-spoiler-too.mdx
@@ -28,7 +28,7 @@ blurb: Ranked-choice voting is the standard fix for the spoiler effect that hand
   }, 100)
 </script>
 
-[Last time](/posts/visualizing-voting-systems) we watched Nader spoil the 2000 election for Gore under plurality voting, and saw approval voting fix it. Approval voting is a hard sell politically though; the reform that's actually spreading city by city, state by state, is [ranked-choice voting](https://fairvote.org/our-reforms/ranked-choice-voting/) — voters rank candidates instead of just picking one, and the count runs an instant runoff: repeatedly eliminate whoever has the fewest first-choice votes, transferring their ballots to whichever surviving candidate each of those voters ranked next, until someone has a majority. Does it fix the spoiler effect too?
+## Does instant runoff fix the spoiler effect?
 
 <IntersectionObserver initialHeight={600}>
   <YeeDiagram
@@ -38,9 +38,7 @@ blurb: Ranked-choice voting is the standard fix for the spoiler effect that hand
   />
 </IntersectionObserver>
 
-Mostly, yes. Nader's region shrinks to almost nothing, because a Nader voter's second choice is a factor now: once Nader is eliminated for having the fewest first-choice votes, his voters transfer to Gore, and Gore wins the runoff the same way he would have if Nader had never run. This is the headline case for ranked-choice voting, and it's real.
-
-But notice the mechanism: Nader had to be eliminated *first* for those voters to ever reach Gore. If a compromise candidate has too few first-choice votes, they get eliminated before their broad second-choice support ever counts for anything. This failure mode has a name: [center squeeze](https://electionscience.org/library/center-squeeze/). Drag the polarization slider below and watch the red candidate — sitting exactly between the other two, closer to more of the electorate than anyone else — lose ground even in cells where it's the nearest candidate to the average voter.
+## Center squeeze
 
 <input
   type="range"
@@ -61,6 +59,4 @@ But notice the mechanism: Nader had to be eliminated *first* for those voters to
   />
 </IntersectionObserver>
 
-At low polarization, red owns the middle band, same as you'd expect. Push the slider up and the electorate splits into two camps, one nearer blue and one nearer yellow, with hardly anyone left near red as a first choice. Red gets eliminated in the first round, and the runoff becomes a contest between blue and yellow — the two candidates furthest from the average voter — decided by whichever camp happens to be slightly larger. The candidate closest to the middle of the electorate, the one nearly everybody would have been fine with, never gets to compete in the round that matters.
-
-This is why voting theorists don't treat ranked-choice as a solved problem, just a different set of tradeoffs. It fixes the specific pathology plurality has, and introduces its own: it rewards being someone's first choice over being nobody's last choice, which is a different bet on what an election should be measuring in the first place.
+## The tradeoff

--- a/packages/website/src/routes/posts/ranked-choice-has-a-spoiler-too.mdx
+++ b/packages/website/src/routes/posts/ranked-choice-has-a-spoiler-too.mdx
@@ -1,0 +1,66 @@
+---
+title: 'Ranked Choice Voting Has a Spoiler Effect Too'
+date: 2026-07-02 12:00:00
+status: draft
+blurb: Ranked-choice voting is the standard fix for the spoiler effect that handed Bush the 2000 election, and it works. But it trades that failure for a subtler one, where the candidate almost everyone can live with loses just for not being anyone's favorite.
+---
+
+<script>
+  import YeeDiagram from '$lib/voting/YeeDiagram.svelte'
+  import IntersectionObserver from '$lib/IntersectionObserver.svelte'
+  import { debounce } from '$lib/utilities'
+
+  const candidates = [
+    [50, 30],
+    [50, 70],
+    [30, 15]
+  ]
+
+  const squeezeCandidates = [
+    [25, 50],
+    [50, 50],
+    [75, 50]
+  ]
+
+  let polarization = 0
+  const updatePolarization = debounce((e) => {
+    polarization = Number(e.target.value)
+  }, 100)
+</script>
+
+[Last time](/posts/visualizing-voting-systems) we watched Nader spoil the 2000 election for Gore under plurality voting, and saw approval voting fix it. Approval voting is a hard sell politically though; the reform that's actually spreading city by city, state by state, is [ranked-choice voting](https://fairvote.org/our-reforms/ranked-choice-voting/) — voters rank candidates instead of just picking one, and the count runs an instant runoff: repeatedly eliminate whoever has the fewest first-choice votes, transferring their ballots to whichever surviving candidate each of those voters ranked next, until someone has a majority. Does it fix the spoiler effect too?
+
+<IntersectionObserver initialHeight={600}>
+  <YeeDiagram
+    candidates={candidates}
+    method="irv"
+    label="The same 2000 candidates, counted by instant runoff instead of plurality. Compare this to the plurality diagram in the last post."
+  />
+</IntersectionObserver>
+
+Mostly, yes. Nader's region shrinks to almost nothing, because a Nader voter's second choice is a factor now: once Nader is eliminated for having the fewest first-choice votes, his voters transfer to Gore, and Gore wins the runoff the same way he would have if Nader had never run. This is the headline case for ranked-choice voting, and it's real.
+
+But notice the mechanism: Nader had to be eliminated *first* for those voters to ever reach Gore. If a compromise candidate has too few first-choice votes, they get eliminated before their broad second-choice support ever counts for anything. This failure mode has a name: [center squeeze](https://electionscience.org/library/center-squeeze/). Drag the polarization slider below and watch the red candidate — sitting exactly between the other two, closer to more of the electorate than anyone else — lose ground even in cells where it's the nearest candidate to the average voter.
+
+<input
+  type="range"
+  min="0"
+  max="30"
+  value={polarization}
+  on:input={updatePolarization}
+  style="width: 100%; max-width: 600px; display: block; margin: 0 auto;"
+/>
+
+<IntersectionObserver initialHeight={600}>
+  <YeeDiagram
+    candidates={squeezeCandidates}
+    method="irv"
+    polarization={polarization}
+    portraits={[undefined, undefined, undefined]}
+    label="Blue and yellow flank red at the center. As polarization rises, voters cluster around the two poles, red runs short of first-choice votes, and gets eliminated before its second-choice support ever counts."
+  />
+</IntersectionObserver>
+
+At low polarization, red owns the middle band, same as you'd expect. Push the slider up and the electorate splits into two camps, one nearer blue and one nearer yellow, with hardly anyone left near red as a first choice. Red gets eliminated in the first round, and the runoff becomes a contest between blue and yellow — the two candidates furthest from the average voter — decided by whichever camp happens to be slightly larger. The candidate closest to the middle of the electorate, the one nearly everybody would have been fine with, never gets to compete in the round that matters.
+
+This is why voting theorists don't treat ranked-choice as a solved problem, just a different set of tradeoffs. It fixes the specific pathology plurality has, and introduces its own: it rewards being someone's first choice over being nobody's last choice, which is a different bet on what an election should be measuring in the first place.


### PR DESCRIPTION
Codifies the pattern already used by the site's strongest posts
(voting simulations, pi-by-hand) — build the interactive Svelte
visualization before writing prose, and keep prose to framing/
interpretation around it rather than a full explanatory draft.