### PR TITLE
Add PR preview deploy workflow

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,30 @@
+name: PR Preview
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+concurrency: preview-${{ github.ref }}
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: build
+        if: github.event.action != 'closed'
+        run: |
+          npm install
+          npm run build
+
+      - name: deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: packages/website/build
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview


### PR DESCRIPTION
Builds the site on pull_request events and publishes it to
gh-pages/pr-preview/pr-<number>/ via rossjrw/pr-preview-action, so
each PR gets a live preview URL that's cleaned up when the PR closes.